### PR TITLE
Fix ISO week-date parsing when Jan 4 is a Sunday

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   },
   "homepage": "https://github.com/philihp/iso-week-date#readme",
   "devDependencies": {
-    "@babel/cli": "7.10.5",
-    "@babel/core": "7.10.5",
-    "@babel/preset-env": "7.10.4",
-    "@philihp/eslint-config": "3.0.1",
+    "@babel/cli": "^7.28.6",
+    "@babel/core": "^7.29.0",
+    "@babel/preset-env": "^7.29.5",
+    "@philihp/eslint-config": "^3.0.2",
     "husky": "4.2.5",
     "jest": "26.1.0",
     "lint-staged": "10.2.11",
@@ -46,8 +46,5 @@
     "extends": [
       "@philihp"
     ]
-  },
-  "dependencies": {
-    "year-days": "3.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-import days from 'year-days'
-
 const radix = 10
 const hoursPerDay = 24
 const minutesPerDay = 60
@@ -12,13 +10,6 @@ const woy = ([, sWoy]) => Number.parseInt(sWoy.slice(1), radix)
 
 const dow = ([, , sDow]) => Number.parseInt(sDow, radix)
 
-const doy = (y, d) => {
-  if (d > days(y)) {
-    return d - 7
-  }
-  return d
-}
-
 // part of zeller's confluence
 const daysSince = (y) =>
   365 * (y - 1970) +
@@ -26,16 +17,19 @@ const daysSince = (y) =>
   Math.floor((y - 1901) / 100) +
   Math.floor((y - 1601) / 400)
 
-const dowOfJan4 = (y) => new Date(y, january, 4).getDay()
+// ISO weekday: Mon=1..Sun=7 (JS getDay returns Sun=0)
+const isoDowOfJan4 = (y) => {
+  const d = new Date(y, january, 4).getDay()
+  return d === 0 ? 7 : d
+}
 
 export const parse = (input) => {
   const date = input.split('-')
   const y = year(date)
-  const d = woy(date) * 7 + dow(date) - dowOfJan4(y) - 4
-  const dd = doy(y, d)
+  const d = woy(date) * 7 + dow(date) - isoDowOfJan4(y) - 4
   return (
-    (dd + daysSince(y)) * hoursPerDay * minutesPerDay * secondsPerMinute * 1000
+    (d + daysSince(y)) * hoursPerDay * minutesPerDay * secondsPerMinute * 1000
   )
 }
 
-export default undefined
+export default { parse }


### PR DESCRIPTION
## Summary

The library mis-parsed week dates in years where January 4 falls on a Sunday (e.g. 2009, 2004). All 22 tests now pass; previously 4 failed and the build itself was broken.

### Root causes

1. **Wrong weekday convention.** `dowOfJan4` used JS `Date#getDay()` (Sunday = 0), but the ISO week-date formula needs ISO weekday (Sunday = 7). When Jan 4 fell on a Sunday the result was off by 7 days. Fixed by mapping `0 → 7`.
2. **A masking hack in `doy`.** The `if (d > days(y)) return d - 7` branch accidentally compensated for the off-by-7 in W53 cases (so `2009-W53-*` and `2004-W53-*` passed), but it did nothing for W01 cases — so `2009-W01-1..4` produced dates 7 days late (e.g. `2009-01-05` instead of `2008-12-29`). Removed; the `d + daysSince(y)` arithmetic already handles ordinal days outside the year.
3. **Default export was `undefined`.** The README's `import WeekDate from 'week-date'; WeekDate.parse(...)` threw at runtime. Now `export default { parse }`.

### Build/tooling fixes (needed to even run the suite)

- Bumped `@babel/{cli,core,preset-env}` from `7.10.x` to current `^7.29.x` — the old core couldn't load its own newer transitive plugins, so `npm test` errored before running any test.
- Bumped `@philihp/eslint-config` from `3.0.1` → `3.0.2`. `3.0.1` is broken on npm (its own `index.js` requires `./unicorn` which isn't in the package); `3.0.2` ships the missing file. Without this the husky pre-commit hook can't even load eslint.
- Removed the now-unused `year-days` runtime dependency.

## Test plan

- [x] `npm test` — 22/22 pass
- [x] `npm run build` succeeds
- [x] `require('./dist').default.parse('2020-W09-6')` and `require('./dist').parse('2020-W09-6')` both return `2020-02-29T00:00:00.000Z` (matches README)
- [x] Husky pre-commit hook (lint-staged → eslint --fix) runs without error

---
_Generated by [Claude Code](https://claude.ai/code/session_012kyCEBMjjpaWuiAfFmbUqX)_