### PR TITLE
Emit lcov coverage report for Coveralls

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,3 +31,4 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: lcov.info

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ dist/
 node_modules/
 .nyc_output/
 coverage/
+lcov.info
 *.swp
 package-lock.json
 .node-version

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint .",
     "test": "node --test",
     "test:watch": "node --test --watch",
-    "test:coverage": "node --test --experimental-test-coverage"
+    "test:coverage": "node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info --test-reporter=spec --test-reporter-destination=stdout"
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
## Summary

The CI `coverage` job runs `npm run test:coverage`, which used `node --test --experimental-test-coverage` — that only prints a human-readable summary to stdout. The subsequent `coverallsapp/github-action@v2` step therefore had no lcov file to upload, so Coveralls never received real data.

This change:
- Adds the built-in `lcov` test reporter to the `test:coverage` script, writing `lcov.info` while keeping the human-readable `spec` output on stdout.
- Points the Coveralls action at `lcov.info`.
- Gitignores the generated `lcov.info` file.

## Test plan
- [x] `npm run test:coverage` produces `lcov.info` locally and still prints the coverage table.
- [ ] CI `coverage` job uploads results to Coveralls successfully.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xv8x1y58WT3tviiWNrroMu)_